### PR TITLE
Indicate that ipv6 addresses are exported

### DIFF
--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -223,6 +223,7 @@ The following attributes are exported:
 * `public_dns` - The public DNS name assigned to the instance. For EC2-VPC, this
   is only available if you've enabled DNS hostnames for your VPC
 * `public_ip` - The public IP address assigned to the instance, if applicable. **NOTE**: If you are using an [`aws_eip`](/docs/providers/aws/r/eip.html) with your instance, you should refer to the EIP's address directly and not use `public_ip`, as this field will change after the EIP is attached.
+* `ipv6_addresses` - A list of assigned IPv6 addresses, if any
 * `network_interface_id` - The ID of the network interface that was created with the instance.
 * `primary_network_interface_id` - The ID of the instance's primary network interface.
 * `private_dns` - The private DNS name assigned to the instance. Can only be


### PR DESCRIPTION
aws_instance resources export ipv6_addresses which may be used like:
```
 value  = "${element(aws_instance.consul_server.*.ipv6_addresses[0], count.index)}"
```